### PR TITLE
Minor Documentation Fixup

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -776,7 +776,7 @@ curl "https://app.timetastic.co.uk/api/departments/1"
 
 # Leave Types
 
-## Department Detail
+## Leave Type Detail
 
 > A typical leave type response:
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -231,7 +231,7 @@ Parameter | Default | Description
 
 ### Paging
 
-You are limited to 100 holidays in any response. If your query returns more than this, you'll need to request any additional pages. With every request, you get a sumary as shown in the JSON response in the right-hand column.
+You are limited to 100 holidays in any response. If your query returns more than this, you'll need to request any additional pages. With every request, you get a summary as shown in the JSON response in the right-hand column.
 
 By examining this response, you'll be able to determine whether additional requests are needed. The `nextPageLink` will tell you what request to make for the next set of responses.
 


### PR DESCRIPTION
Within the "Leave Type" section a heading "Department Detail" should read "Leave Type Detail".

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->