### PR TITLE
Set up Azure pipelines build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pool:
 steps:
 - task: UseRubyVersion@0
   inputs:
-    versionSpec: '>= 2.5'
+    versionSpec: '2.7.6'
     addToPath: true
 
 - script: |


### PR DESCRIPTION
Setup ApiDocs in CI so we can build them directly into the main website and bring the other PRs in automatically.

